### PR TITLE
change ' to " for __main__

### DIFF
--- a/simple_IMSI-catcher.py
+++ b/simple_IMSI-catcher.py
@@ -538,7 +538,7 @@ def find_imsi_from_pkg(p):
 	udpdata = str(p[UDP].payload)
 	find_imsi(udpdata)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 	imsitracker = tracker()
 	parser = OptionParser(usage="%prog: [options]")
 	parser.add_option("-a", "--alltmsi", action="store_true", dest="show_all_tmsi", help="Show TMSI who haven't got IMSI (default  : false)")


### PR DESCRIPTION
when use `'` i got `/usr/bin/python: can't find '__main__' module in '/home/myusername'` , imsi placed on /home/myusername/IMSI-catcher , Ubuntu 16.04