### PR TITLE
fix 'brand' and 'country' mismatch in stdout header

### DIFF
--- a/simple_IMSI-catcher.py
+++ b/simple_IMSI-catcher.py
@@ -225,7 +225,7 @@ class tracker:
 			self.sqlcon.commit()
 
 	def header(self):
-		print("{:7s} ; {:10s} ; {:10s} ; {:17s} ; {:12s} ; {:10s} ; {:21s} ; {:4s} ; {:5s} ; {:6s} ; {:6s}".format("Nb IMSI", "TMSI-1", "TMSI-2", "IMSI", "country", "brand", "operator", "MCC", "MNC", "LAC", "CellId"))
+		print("{:7s} ; {:10s} ; {:10s} ; {:17s} ; {:12s} ; {:10s} ; {:21s} ; {:4s} ; {:5s} ; {:6s} ; {:6s}".format("Nb IMSI", "TMSI-1", "TMSI-2", "IMSI", "brand", "country", "operator", "MCC", "MNC", "LAC", "CellId"))
 
 	# print "Nb IMSI", "TMSI-1", "TMSI-2", "IMSI", "country", "brand", "operator", "MCC", "MNC", "LAC", "CellId"
 	def register_imsi(self, arfcn, imsi1="", imsi2="", tmsi1="", tmsi2="", p=""):


### PR DESCRIPTION
"brand" and "country" are swapped in the table header.