### PR TITLE
Fix 'apt instal' spelling error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Use `db-example.sql` to create your DB.
 cp .env.dist .env
 nano .env
 # set your config
-sudo apt instal python-decouple python3-mysqldb
+sudo apt install python-decouple python3-mysqldb
 ```
   
 ```bash


### PR DESCRIPTION
There is a spelling mistake in the [mysql](https://github.com/Oros42/IMSI-catcher#log-data-in-mysql) section of the README.
The README says:
`sudo apt instal python-decouple python3-mysqldb`
When it should be:
`sudo apt install python-decouple python3-mysqldb`
This PR corrects that.