### PR TITLE
Update simple_IMSI-catcher.py - fixed possible copy-paste

### DIFF
--- a/simple_IMSI-catcher.py
+++ b/simple_IMSI-catcher.py
@@ -291,7 +291,7 @@ class tracker:
                 if tmsi1 and tmsi1 not in self.tmsis:
                     do_print = True
                     self.tmsis[tmsi1] = ""
-                if tmsi1 and tmsi1 not in self.tmsis:
+                if tmsi2 and tmsi2 not in self.tmsis:
                     do_print = True
                     self.tmsis[tmsi2] = ""
                 if do_print:


### PR DESCRIPTION
Inside of `def register_imsi(self, arfcn, imsi1="", imsi2="", tmsi1="", tmsi2="", p=""):` spotted the next piece of code:

```python3
if self.show_all_tmsi:
    do_print = False
    if tmsi1 and tmsi1 not in self.tmsis: # <-- Check for 'tmsi1'
        do_print = True
        self.tmsis[tmsi1] = ""            # <-- Assigned empty 'imsi' by 'tmsi1' key
    if tmsi1 and tmsi1 not in self.tmsis: # <-- Check for 'tmsi1' (again), possibly here must be 'tmsi2'
        do_print = True
        self.tmsis[tmsi2] = ""            # <-- Assigned empty 'imsi' by 'tmsi2' key
```

I'm definitely dont know what happens here (and why) but it looks like second `if tmsi1 and tmsi1 not in self.tmsis:` must be `if tmsi2 and tmsi2 not in self.tmsis:`.