### PR TITLE
Update README.md - updated install instructions (python3-docutils package name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sudo apt-get install -y \
     libtool \
     pkg-config \
     build-essential \
-    python-docutils \
+    python3-docutils \
     libcppunit-dev \
     swig \
     doxygen \


### PR DESCRIPTION
Greetings! On my `Ubuntu 22.04.5 LTS`, during installing required packages, I spotted that `python-docutils` not found in `apt` repository, since it named as `python3-docutils`. 

Maybe it will be good to update instructions (accept this PR)?  Or just close it, if its not acceptable (if you primary targets are older distros).