### PR TITLE
Update base image and package installations in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update
 
 # GR-GSM
 RUN export TZ=America/New_York && export DEBIAN_FRONTEND=noninteractive && apt-get install -y  gnuradio gnuradio-dev git cmake autoconf libtool pkg-config g++ gcc make libc6 \
-libc6-dev libcppunit-dev libcppunit-dev swig doxygen liblog4cpp5v5 liblog4cpp5-dev python3-scipy \
+libc6-dev libcppunit-dev swig doxygen liblog4cpp5v5 liblog4cpp5-dev python3-scipy \
 gr-osmosdr libosmocore libosmocore-dev
 
 RUN git clone https://github.com/bkerler/gr-gsm.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:resolute
 
 MAINTAINER Dmitry Abakumov, a.k.a 0MazaHacka0 <killerinshadow2@gmail.com>
 
@@ -7,15 +7,15 @@ RUN apt-get update
 
 # GR-GSM
 RUN export TZ=America/New_York && export DEBIAN_FRONTEND=noninteractive && apt-get install -y  gnuradio gnuradio-dev git cmake autoconf libtool pkg-config g++ gcc make libc6 \
-libc6-dev libcppunit-1.14-0 libcppunit-dev swig doxygen liblog4cpp5v5 liblog4cpp5-dev python-scipy \
+libc6-dev libcppunit-dev libcppunit-dev swig doxygen liblog4cpp5v5 liblog4cpp5-dev python3-scipy \
 gr-osmosdr libosmocore libosmocore-dev
 
-RUN git clone https://git.osmocom.org/gr-gsm
+RUN git clone https://github.com/bkerler/gr-gsm.git
 
 RUN cd gr-gsm && mkdir build && cd build && cmake .. && make && make install && ldconfig
 
 # IMSI-catcher script
-RUN apt-get install -y python-numpy python-scipy python-scapy
+RUN apt-get install -y python3-numpy python3-scipy python3-scapy
 
 ADD . /imsi-catcher/
 


### PR DESCRIPTION
- bumped ubuntu base image from `bionic` to `resolute`.
- changed `python-` packages to `python3-`.
- dropped the `libcppunit` package, as we're installing `libcppuit-dev` anygays.

Tested using podman on my machine™, but should work with docker as well. 

@0MazaHacka0 just an FYI, as you're the still listed as the Dockerfile's maintainer.